### PR TITLE
no need for sed - env should already be here

### DIFF
--- a/templates/linux/Dockerfile
+++ b/templates/linux/Dockerfile
@@ -1,4 +1,2 @@
 FROM nelioteam/meteord:base
 #docker build -t nelioteam/meteord:base-update .
-
-RUN sed -i -e 's/node main.js/export MONGO_URL=$(cat \/run\/secrets\/mongo_url) \&\& echo \$MONGO_URL \&\& node main.js/g' $METEORD_DIR/run_app.sh


### PR DESCRIPTION
Hello,

Cette Pr enleve le sed du template docker.

l'env peut être donnée directement au container lors de l'execution